### PR TITLE
docs: Add mention of the parent folder

### DIFF
--- a/docs/developer-guide/toolchain-guide.md
+++ b/docs/developer-guide/toolchain-guide.md
@@ -244,7 +244,7 @@ If you touched UI code, you should also run the Yarn linter on it:
 Argo CD, along with Argo Workflows, uses shared React components from [Argo UI](https://github.com/argoproj/argo-ui). Examples of some of these components include buttons, containers, form controls, 
 and others. Although you can make changes to these files and run them locally, in order to have these changes added to the Argo CD repo, you will need to follow these steps. 
 
-1. Fork and clone the [Argo UI repository](https://github.com/argoproj/argo-ui).
+1. Fork and clone the [Argo UI repository](https://github.com/argoproj/argo-ui) inside the same parent folder as `argo-cd`.
 
 2. `cd` into your `argo-ui` directory, and then run `yarn install`. 
 


### PR DESCRIPTION
I was going through the instructions today and noticed that for a newbie putting the `argo-ui` folder in the same parent folder as the rest of the Argo components might not be super-obvious and could be mentioned on the 1st step rather than the 4th one.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

